### PR TITLE
fix flaky test

### DIFF
--- a/pkg/query/get-existing-attrs_test.go
+++ b/pkg/query/get-existing-attrs_test.go
@@ -47,5 +47,5 @@ func TestGetExistingAttributes(t *testing.T) {
 		keys[i] = key
 		i++
 	}
-	assert.Equal(t, keys, []string{"style", "class"})
+	assert.ElementsMatch(t, keys, []string{"style", "class"})
 }


### PR DESCRIPTION
get-existing-attrs-test is flaky because the ordering of keys unstable. it is possible to reproduce this by running `go test -count=1 ./pkg/query` a few times:

    λ make test
    ?       github.com/opa-oz/pug-lsp/pkg/completion        [no test files]
    ok      github.com/opa-oz/pug-lsp/pkg/utils     0.002s
    [TODO]: "Is 5 enough?"
    style="padding: 8px;"
    attributes (style="padding: 8px;" class="my class")
    --- FAIL: TestGetExistingAttributes (0.00s)
        get-existing-attrs_test.go:50:
                    Error Trace:    /home/op/leet/pug-lsp/pkg/query/get-existing-attrs_test.go:50
                    Error:          Not equal:
                                    expected: []string{"class", "style"}
                                    actual  : []string{"style", "class"}

                                    Diff:
                                    --- Expected
                                    +++ Actual
                                    @@ -1,4 +1,4 @@
                                     ([]string) (len=2) {
                                    - (string) (len=5) "class",
                                    - (string) (len=5) "style"
                                    + (string) (len=5) "style",
                                    + (string) (len=5) "class"
                                     }
                    Test:           TestGetExistingAttributes
    FAIL
    FAIL    github.com/opa-oz/pug-lsp/pkg/query     0.006s
    ok      github.com/opa-oz/pug-lsp/pkg/html      0.002s
    ok      github.com/opa-oz/pug-lsp/pkg/documents 0.005s
    ok      github.com/opa-oz/pug-lsp/pkg/lsp       0.002s
    FAIL
    make: *** [Makefile:10: test] Error 1